### PR TITLE
Replace backslashes with slashes to fix on non-windows platforms

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
         let ter1 = vscode.window.createTerminal({name:'instance'});
         ter1.show(true);
-        ter1.sendText(`python ${__dirname}\\vInstance_Gen.py ${editor.document.fileName}`);
+        ter1.sendText(`python ${__dirname}/vInstance_Gen.py ${editor.document.fileName}`);
 
         // Display a message box to the user
         vscode.window.showInformationMessage('Generate instance successfully!');
@@ -38,7 +38,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
         let ter1 = vscode.window.createTerminal({name:'testbench'});
         ter1.show(true);
-        ter1.sendText(`python ${__dirname}\\vTbgenerator.py ${editor.document.fileName}`);
+        ter1.sendText(`python ${__dirname}/vTbgenerator.py ${editor.document.fileName}`);
 
         // Display a message box to the user
         vscode.window.showInformationMessage('Generate testbench successfully!');


### PR DESCRIPTION
The extension fails on non-Windows platforms (i.e., Linux) because the path to the python scripts is using a backslash separator.  This PR changes it to a slash, which _should_ work on both Windows and Linux.

Note:  I don't have a Windows machine with VS Code right now to test with, so please test this change before merging.  But I believe it should correct the problem and work on all platforms.